### PR TITLE
Defer the promises of observeDevices/observeGroups until the devices/groups are received

### DIFF
--- a/build/lib/defer-promise.d.ts
+++ b/build/lib/defer-promise.d.ts
@@ -1,0 +1,5 @@
+export interface DeferredPromise<T> extends Promise<T> {
+    resolve(value?: T | PromiseLike<T>): void;
+    reject(reason?: any): void;
+}
+export declare function createDeferredPromise<T>(): DeferredPromise<T>;

--- a/build/lib/defer-promise.js
+++ b/build/lib/defer-promise.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function createDeferredPromise() {
+    let res;
+    let rej;
+    const promise = new Promise((resolve, reject) => {
+        res = resolve;
+        rej = reject;
+    });
+    promise.resolve = res;
+    promise.reject = rej;
+    return promise;
+}
+exports.createDeferredPromise = createDeferredPromise;

--- a/build/tradfri-client.d.ts
+++ b/build/tradfri-client.d.ts
@@ -78,6 +78,11 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
      */
     observeResource(path: string, callback: (resp: CoapResponse) => void): Promise<boolean>;
     /**
+     * Checks if a resource is currently being observed
+     * @param path The path of the resource
+     */
+    isObserving(path: string): boolean;
+    /**
      * Stops observing a resource that is being observed through `observeResource`
      * Use the specialized version of this method for observers that were set up with the specialized versions of `observeResource`
      * @param path The path of the resource
@@ -96,16 +101,22 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
      * This does not stop observing the resources if the observers are still active
      */
     private clearObservers();
+    private observeDevicesPromise;
     /**
      * Sets up an observer for all devices
      * @returns A promise that resolves when the information about all devices has been received.
      */
     observeDevices(): Promise<void>;
-    private observeDevices_callback(observePromise, response);
+    private observeDevices_callback(response);
     stopObservingDevices(): void;
     private observeDevice_callback(instanceId, response);
-    /** Sets up an observer for all groups */
-    observeGroupsAndScenes(): Promise<this>;
+    private observeGroupsPromise;
+    private observeScenesPromises;
+    /**
+     * Sets up an observer for all groups and scenes
+     * @returns A promise that resolves when the information about all groups and scenes has been received.
+     */
+    observeGroupsAndScenes(): Promise<void>;
     private observeGroups_callback(response);
     stopObservingGroups(): void;
     private stopObservingGroup(instanceId);

--- a/build/tradfri-client.d.ts
+++ b/build/tradfri-client.d.ts
@@ -96,9 +96,12 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
      * This does not stop observing the resources if the observers are still active
      */
     private clearObservers();
-    /** Sets up an observer for all devices */
-    observeDevices(): Promise<this>;
-    private observeDevices_callback(response);
+    /**
+     * Sets up an observer for all devices
+     * @returns A promise that resolves when the information about all devices has been received.
+     */
+    observeDevices(): Promise<void>;
+    private observeDevices_callback(observePromise, response);
     stopObservingDevices(): void;
     private observeDevice_callback(instanceId, response);
     /** Sets up an observer for all groups */

--- a/build/tradfri-client.js
+++ b/build/tradfri-client.js
@@ -187,7 +187,7 @@ class TradfriClient extends events_1.EventEmitter {
                     // check if we have received information about all devices
                     if (observePromise != null) {
                         if (result) {
-                            if (newKeys.each(k => k in this.devices)) {
+                            if (newKeys.every(k => k in this.devices)) {
                                 observePromise.resolve();
                                 observePromise = null;
                             }

--- a/src/lib/defer-promise.test.ts
+++ b/src/lib/defer-promise.test.ts
@@ -38,8 +38,7 @@ describe("lib/defer-promise => createDeferredPromise() =>", () => {
 	promiseTwice.resolve();
 
 	it("should not resolve twice", () => {
-		leSpy.should.have.been.calledOnce;
-		leSpy.should.not.have.been.calledTwice;
+		expect(leSpy.callCount).to.equal(1);
 	});
 
 });

--- a/src/lib/defer-promise.test.ts
+++ b/src/lib/defer-promise.test.ts
@@ -1,5 +1,6 @@
 import {expect, use } from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { spy } from "sinon";
 
 before(() => {
 	use(chaiAsPromised);
@@ -27,6 +28,18 @@ describe("lib/defer-promise => createDeferredPromise() =>", () => {
 		const promiseRej = createDeferredPromise<boolean>();
 		promiseRej.reject();
 		return expect(promiseRej).to.be.rejected;
+	});
+
+	const leSpy = spy();
+	const promiseTwice = createDeferredPromise<void>();
+	promiseTwice.then(leSpy);
+
+	promiseTwice.resolve();
+	promiseTwice.resolve();
+
+	it("should not resolve twice", () => {
+		leSpy.should.have.been.calledOnce;
+		leSpy.should.not.have.been.calledTwice;
 	});
 
 });

--- a/src/tradfri-client.test.ts
+++ b/src/tradfri-client.test.ts
@@ -127,12 +127,15 @@ describe("tradfri-client => ", () => {
 
 	describe("observeDevices => ", () => {
 
-		it("should call coap.observe for the devices endpoint", async () => {
-			await tradfri.observeDevices();
-			fakeCoap.observe.should.have.been.calledWith(devicesUrl);
-		});
+		it("should call coap.observe for the devices endpoint and for each observed device", async () => {
+			// remember the deferred promise
+			const devicesPromise = tradfri.observeDevices();
 
-		it("should call coap.observe for each observed device", async () => {
+			fakeCoap.observe.should.have.been.calledOnce;
+			fakeCoap.observe.should.have.been.calledWith(devicesUrl);
+
+			fakeCoap.observe.resetHistory();
+
 			const devices = [65536, 65537];
 			await observeDevices_callback(createResponse(devices));
 
@@ -144,6 +147,9 @@ describe("tradfri-client => ", () => {
 			// now for the following tests to work
 			await observeDevice_callbacks[65536](createResponse(emptyAccessory));
 			await observeDevice_callbacks[65537](createResponse(emptyAccessory));
+
+			// now the deferred promise should have resolved
+			await devicesPromise;
 		});
 
 		it("when a device is added, it should only call observe for that one", async () => {

--- a/src/tradfri-client.ts
+++ b/src/tradfri-client.ts
@@ -231,7 +231,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 			this.emit("error", new Error(`unexpected response (${response.code.toString()}) to observeDevices.`));
 			return;
 		}
-		const newDevices = parsePayload(response);
+		const newDevices: number[] = parsePayload(response);
 
 		log(`got all devices: ${JSON.stringify(newDevices)}`);
 
@@ -251,7 +251,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 				// check if we have received information about all devices
 				if (observePromise != null) {
 					if (result) {
-						if (newKeys.each(k => k in this.devices)) {
+						if (newKeys.every(k => k in this.devices)) {
 							observePromise.resolve();
 							observePromise = null;
 						}


### PR DESCRIPTION
Resolves #6 

- [x] defer `observeDevices`
- [x] defer `observeGroups`
- [x] fix broken tests for `observeDevices`
- [ ] fix broken tests for `observeGroups`