### PR TITLE
Support using raw CoAP values

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ A DeviceInfo object contains general information about a device. It has the foll
 
 ## Changelog
 
+#### 0.7.0 (2018-01-28)
+* (AlCalzone) Support using raw CoAP values instead of the simplified scales for many properties.
+
 #### 0.6.0 (2018-01-13)
 * (AlCalzone) Use the `colorTemperature` CoAP property directly instead of `colorX/Y`
 

--- a/build/lib/accessory.d.ts
+++ b/build/lib/accessory.d.ts
@@ -1,7 +1,6 @@
 import { DeviceInfo } from "./deviceInfo";
 import { IPSODevice } from "./ipsoDevice";
 import { Light } from "./light";
-import { OperationProvider } from "./operation-provider";
 import { Plug } from "./plug";
 import { Sensor } from "./sensor";
 export declare enum AccessoryTypes {
@@ -19,10 +18,4 @@ export declare class Accessory extends IPSODevice {
     sensorList: Sensor[];
     switchList: IPSODevice[];
     otaUpdateState: number;
-    /**
-     * Link this object to a TradfriClient for a simplified API.
-     * INTERNAL USE ONLY!
-     * @param client The client instance to link this object to
-     */
-    link(client: OperationProvider): this;
 }

--- a/build/lib/accessory.js
+++ b/build/lib/accessory.js
@@ -34,8 +34,8 @@ class Accessory extends ipsoDevice_1.IPSODevice {
     }
     /**
      * Link this object to a TradfriClient for a simplified API.
-     * INTERNAL USE ONLY!
      * @param client The client instance to link this object to
+     * @internal
      */
     link(client) {
         super.link(client);
@@ -68,7 +68,7 @@ __decorate([
 ], Accessory.prototype, "type", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("3"),
-    ipsoObject_1.deserializeWith(obj => new deviceInfo_1.DeviceInfo().parse(obj)),
+    ipsoObject_1.deserializeWith((obj, me) => new deviceInfo_1.DeviceInfo(me.options).parse(obj)),
     __metadata("design:type", deviceInfo_1.DeviceInfo)
 ], Accessory.prototype, "deviceInfo", void 0);
 __decorate([
@@ -81,22 +81,22 @@ __decorate([
 ], Accessory.prototype, "lastSeen", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("3311"),
-    ipsoObject_1.deserializeWith((obj, me) => new light_1.Light(me).parse(obj)),
+    ipsoObject_1.deserializeWith((obj, me) => new light_1.Light(me, me.options).parse(obj)),
     __metadata("design:type", Array)
 ], Accessory.prototype, "lightList", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("3312"),
-    ipsoObject_1.deserializeWith(obj => new plug_1.Plug().parse(obj)),
+    ipsoObject_1.deserializeWith((obj, me) => new plug_1.Plug(me.options).parse(obj)),
     __metadata("design:type", Array)
 ], Accessory.prototype, "plugList", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("3300"),
-    ipsoObject_1.deserializeWith(obj => new sensor_1.Sensor().parse(obj)),
+    ipsoObject_1.deserializeWith((obj, me) => new sensor_1.Sensor(me.options).parse(obj)),
     __metadata("design:type", Array)
 ], Accessory.prototype, "sensorList", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("15009"),
-    ipsoObject_1.deserializeWith(obj => new ipsoDevice_1.IPSODevice().parse(obj)),
+    ipsoObject_1.deserializeWith((obj, me) => new ipsoDevice_1.IPSODevice(me.options).parse(obj)),
     __metadata("design:type", Array)
 ], Accessory.prototype, "switchList", void 0);
 __decorate([

--- a/build/lib/conversions.d.ts
+++ b/build/lib/conversions.d.ts
@@ -1,17 +1,17 @@
-import { PropertyTransform } from "./ipsoObject";
+import { PropertyTransformKernel } from "./ipsoObject";
 export declare const serializers: {
-    transitionTime: PropertyTransform;
-    hue: PropertyTransform;
-    saturation: PropertyTransform;
-    brightness: PropertyTransform;
-    colorTemperature: PropertyTransform;
+    transitionTime: PropertyTransformKernel;
+    hue: PropertyTransformKernel;
+    saturation: PropertyTransformKernel;
+    brightness: PropertyTransformKernel;
+    colorTemperature: PropertyTransformKernel;
 };
 export declare const deserializers: {
-    transitionTime: PropertyTransform;
-    hue: PropertyTransform;
-    saturation: PropertyTransform;
-    brightness: PropertyTransform;
-    colorTemperature: PropertyTransform;
+    transitionTime: PropertyTransformKernel;
+    hue: PropertyTransformKernel;
+    saturation: PropertyTransformKernel;
+    brightness: PropertyTransformKernel;
+    colorTemperature: PropertyTransformKernel;
 };
 export declare const conversions: {
     rgbFromCIExyY: (x: number, y: number, Y?: number) => {

--- a/build/lib/group.d.ts
+++ b/build/lib/group.d.ts
@@ -1,9 +1,8 @@
 import { IPSODevice } from "./ipsoDevice";
-import { DictionaryLike } from "./object-polyfill";
 import { Scene } from "./scene";
 export interface GroupInfo {
     group: Group;
-    scenes: DictionaryLike<Scene>;
+    scenes: Record<string, Scene>;
 }
 export declare class Group extends IPSODevice {
     onOff: boolean;

--- a/build/lib/group.js
+++ b/build/lib/group.js
@@ -113,7 +113,7 @@ __decorate([
 __decorate([
     ipsoObject_1.ipsoKey("9018"),
     ipsoObject_1.deserializeWith(obj => parseAccessoryLink(obj)),
-    ipsoObject_1.serializeWith(ids => toAccessoryLink(ids), false),
+    ipsoObject_1.serializeWith(ids => toAccessoryLink(ids), { splitArrays: false }),
     __metadata("design:type", Array)
 ], Group.prototype, "deviceIDs", void 0);
 __decorate([
@@ -122,8 +122,8 @@ __decorate([
     // all other properties don't support the transition time
     ,
     ipsoObject_1.required((me, ref) => ref != null && me.dimmer !== ref.dimmer),
-    ipsoObject_1.serializeWith(conversions_1.serializers.transitionTime),
-    ipsoObject_1.deserializeWith(conversions_1.deserializers.transitionTime),
+    ipsoObject_1.serializeWith(conversions_1.serializers.transitionTime, { neverSkip: true }),
+    ipsoObject_1.deserializeWith(conversions_1.deserializers.transitionTime, { neverSkip: true }),
     __metadata("design:type", Number)
 ], Group.prototype, "transitionTime", void 0);
 exports.Group = Group;

--- a/build/lib/ipsoObject.d.ts
+++ b/build/lib/ipsoObject.d.ts
@@ -1,6 +1,11 @@
-import { DictionaryLike } from "./object-polyfill";
 import { OperationProvider } from "./operation-provider";
-export declare type PropertyTransform = (value: any, parent?: IPSOObject) => any;
+export declare type PropertyTransformKernel = (value: any, parent?: IPSOObject) => any;
+export interface PropertyTransform extends PropertyTransformKernel {
+    /** If this transform is not supposed to be skipped ever */
+    neverSkip: boolean;
+    /** If this transform requires arrays to be split */
+    splitArrays: boolean;
+}
 export declare type RequiredPredicate = (me: IPSOObject, reference: IPSOObject) => boolean;
 /**
  * Defines the ipso key neccessary to serialize a property to a CoAP object
@@ -13,15 +18,21 @@ export declare const required: (predicate?: boolean | RequiredPredicate) => Prop
 /**
  * Defines the required transformations to serialize a property to a CoAP object
  * @param transform: The transformation to apply during serialization
- * @param splitArrays: Whether the serializer expects arrays to be split up in advance
+ * @param options: Some options regarding the behavior of the property transform
  */
-export declare const serializeWith: (transform: PropertyTransform, splitArrays?: boolean) => PropertyDecorator;
+export declare function serializeWith(kernel: PropertyTransformKernel, options?: {
+    splitArrays?: boolean;
+    neverSkip?: boolean;
+}): PropertyDecorator;
 /**
  * Defines the required transformations to deserialize a property from a CoAP object
  * @param transform: The transformation to apply during deserialization
  * @param splitArrays: Whether the deserializer expects arrays to be split up in advance
  */
-export declare const deserializeWith: (transforms: PropertyTransform | PropertyTransform[], splitArrays?: boolean) => PropertyDecorator;
+export declare function deserializeWith(kernel: PropertyTransformKernel, options?: {
+    splitArrays?: boolean;
+    neverSkip?: boolean;
+}): PropertyDecorator;
 /**
  * Defines that a property will not be serialized
  */
@@ -33,7 +44,7 @@ export interface IPSOOptions {
     /**
      * Determines if basic serializers (i.e. for simple values) should be skipped
      * This is used to support raw CoAP values instead of the simplified scales
-     * */
+     */
     skipBasicSerializers?: boolean;
 }
 export declare class IPSOObject {
@@ -41,14 +52,14 @@ export declare class IPSOObject {
     /**
      * Reads this instance's properties from the given object
      */
-    parse(obj: DictionaryLike<any>): this;
-    private parseValue(propKey, value, deserializers?, requiresArraySplitting?);
+    parse(obj: Record<string, any>): this;
+    private parseValue(propKey, value, transform?, requiresArraySplitting?);
     /**
      * Overrides this object's properties with those from another partial one
      */
     merge(obj: Partial<this>): this;
     /** serializes this object in order to transfer it via COAP */
-    serialize(reference?: any): DictionaryLike<any>;
+    serialize(reference?: any): Record<string, any>;
     /**
      * Deeply clones an IPSO Object
      */

--- a/build/lib/ipsoObject.d.ts
+++ b/build/lib/ipsoObject.d.ts
@@ -26,7 +26,18 @@ export declare const deserializeWith: (transforms: PropertyTransform | PropertyT
  * Defines that a property will not be serialized
  */
 export declare const doNotSerialize: (target: object, property: string | symbol) => void;
+/**
+ * Provides a set of options regarding IPSO objects and serialization
+ */
+export interface IPSOOptions {
+    /**
+     * Determines if basic serializers (i.e. for simple values) should be skipped
+     * This is used to support raw CoAP values instead of the simplified scales
+     * */
+    skipBasicSerializers?: boolean;
+}
 export declare class IPSOObject {
+    constructor(options?: IPSOOptions);
     /**
      * Reads this instance's properties from the given object
      */
@@ -54,10 +65,4 @@ export declare class IPSOObject {
      */
     createProxy(get?: (me: this, key: PropertyKey) => any, set?: (me: this, key: PropertyKey, value, receiver) => boolean): this;
     protected client: OperationProvider;
-    /**
-     * Link this object to a TradfriClient for a simplified API.
-     * INTERNAL USE ONLY!
-     * @param client The client instance to link this object to
-     */
-    link(client: OperationProvider): this;
 }

--- a/build/lib/ipsoObject.js
+++ b/build/lib/ipsoObject.js
@@ -232,9 +232,10 @@ function getPropertyType(target, property) {
 }
 // common base class for all objects that are transmitted somehow
 class IPSOObject {
-    constructor() {
+    constructor(options = {}) {
         /** If this object was proxied or not */
         this.isProxy = false;
+        this.options = options;
     }
     /**
      * Reads this instance's properties from the given object
@@ -282,7 +283,7 @@ class IPSOObject {
                 logger_1.log(`could not find deserializer for key ${propKey}`, "warn");
             }
         }
-        else if (deserializers) {
+        else if (deserializers && !this.options.skipBasicSerializers) {
             // if this property needs a parser, parse the value
             return applyDeserializers(deserializers, value, this);
         }
@@ -332,7 +333,7 @@ class IPSOObject {
                     // there is no default value, just remember the actual value
                 }
             }
-            if (transform)
+            if (transform && !this.options.skipBasicSerializers)
                 _ret = transform(_ret, this);
             return _ret;
         };
@@ -392,7 +393,7 @@ class IPSOObject {
      */
     clone() {
         const constructor = this.constructor;
-        const ret = new constructor();
+        const ret = new constructor(this.options);
         // serialize the old values
         const serialized = this.serialize();
         // and parse them back
@@ -471,7 +472,7 @@ class IPSOObject {
     }
     /**
      * Link this object to a TradfriClient for a simplified API.
-     * INTERNAL USE ONLY!
+     * @internal
      * @param client The client instance to link this object to
      */
     link(client) {
@@ -479,6 +480,10 @@ class IPSOObject {
         return this;
     }
 }
+__decorate([
+    exports.doNotSerialize,
+    __metadata("design:type", Object)
+], IPSOObject.prototype, "options", void 0);
 __decorate([
     exports.doNotSerialize,
     __metadata("design:type", Boolean)

--- a/build/lib/light.d.ts
+++ b/build/lib/light.d.ts
@@ -1,8 +1,9 @@
 import { Accessory } from "./accessory";
 import { IPSODevice } from "./ipsoDevice";
+import { IPSOOptions } from "./ipsoObject";
 export declare type LightOperation = Partial<Pick<Light, "onOff" | "dimmer" | "color" | "colorTemperature" | "colorX" | "colorY" | "hue" | "saturation" | "transitionTime">>;
 export declare class Light extends IPSODevice {
-    constructor(accessory?: Accessory);
+    constructor(accessory?: Accessory, options?: IPSOOptions);
     private _modelName;
     private _accessory;
     color: string;

--- a/build/lib/light.js
+++ b/build/lib/light.js
@@ -283,8 +283,8 @@ __decorate([
 __decorate([
     ipsoObject_1.ipsoKey("5712"),
     ipsoObject_1.required(),
-    ipsoObject_1.serializeWith(conversions_1.serializers.transitionTime),
-    ipsoObject_1.deserializeWith(conversions_1.deserializers.transitionTime),
+    ipsoObject_1.serializeWith(conversions_1.serializers.transitionTime, { neverSkip: true }),
+    ipsoObject_1.deserializeWith(conversions_1.deserializers.transitionTime, { neverSkip: true }),
     __metadata("design:type", Number)
 ], Light.prototype, "transitionTime", void 0);
 __decorate([

--- a/build/lib/light.js
+++ b/build/lib/light.js
@@ -24,8 +24,8 @@ const ipsoObject_1 = require("./ipsoObject");
 const math_1 = require("./math");
 const predefined_colors_1 = require("./predefined-colors");
 class Light extends ipsoDevice_1.IPSODevice {
-    constructor(accessory) {
-        super();
+    constructor(accessory, options) {
+        super(options);
         this.color = "f1e0b5"; // hex string
         this.transitionTime = 0.5; // <float>
         /**

--- a/build/lib/lightSetting.js
+++ b/build/lib/lightSetting.js
@@ -16,8 +16,8 @@ class LightSetting extends ipsoDevice_1.IPSODevice {
     constructor() {
         super(...arguments);
         this.color = "f1e0b5"; // hex string
-        this.hue = 0; // TODO: TODO: range unknown! [0-359]?
-        this.saturation = 0; // TODO: range unknown!
+        this.hue = 0; // [0-359]
+        this.saturation = 0; // [0..100%]
         this.colorX = 0; // int
         this.colorY = 0; // int
         this.colorTemperature = 0; // TODO: range unknown!

--- a/build/lib/notification.d.ts
+++ b/build/lib/notification.d.ts
@@ -1,8 +1,7 @@
 import { IPSODevice } from "./ipsoDevice";
-import { DictionaryLike } from "./object-polyfill";
 export declare class Notification extends IPSODevice {
     event: NotificationTypes;
-    details: DictionaryLike<string>;
+    details: Record<string, string>;
     state: number;
 }
 export declare enum NotificationTypes {

--- a/build/lib/notification.js
+++ b/build/lib/notification.js
@@ -25,7 +25,7 @@ __decorate([
 ], Notification.prototype, "event", void 0);
 __decorate([
     ipsoObject_1.ipsoKey("9017"),
-    ipsoObject_1.deserializeWith(arr => parseNotificationDetails(arr), false /* parse whole arrays */),
+    ipsoObject_1.deserializeWith(arr => parseNotificationDetails(arr), { splitArrays: false }),
     __metadata("design:type", Object)
 ], Notification.prototype, "details", void 0);
 __decorate([

--- a/build/lib/object-polyfill.d.ts
+++ b/build/lib/object-polyfill.d.ts
@@ -1,26 +1,23 @@
-export interface DictionaryLike<T> {
-    [key: string]: T;
-}
 export declare type Predicate<T> = (value: T) => boolean;
 export declare type KeyValuePair<T> = [string, T];
 /**
  * Stellt einen Polyfill für Object.entries bereit
  * @param obj Das Objekt, dessen Eigenschaften als Key-Value-Pair iteriert werden sollen
  */
-export declare function entries<T>(obj: DictionaryLike<T>): KeyValuePair<T>[];
+export declare function entries<T>(obj: Record<string, T>): KeyValuePair<T>[];
 /**
  * Stellt einen Polyfill für Object.values bereit
  * @param obj Das Objekt, dessen Eigenschaftswerte iteriert werden sollen
  */
-export declare function values<T>(obj: DictionaryLike<T>): T[];
+export declare function values<T>(obj: Record<string, T>): T[];
 /**
  * Gibt ein Subset eines Objekts zurück, dessen Eigenschaften einem Filter entsprechen
  * @param obj Das Objekt, dessen Eigenschaften gefiltert werden sollen
  * @param predicate Die Filter-Funktion, die auf Eigenschaften angewendet wird
  */
-export declare function filter<T>(obj: DictionaryLike<T>, predicate: Predicate<T>): DictionaryLike<T>;
+export declare function filter<T>(obj: Record<string, T>, predicate: Predicate<T>): Record<string, T>;
 /**
  * Kombinierte mehrere Key-Value-Paare zu einem Objekt
  * @param properties Die Key-Value-Paare, die zu einem Objekt kombiniert werden sollen
  */
-export declare function composeObject<T>(properties: KeyValuePair<T>[]): DictionaryLike<T>;
+export declare function composeObject<T>(properties: KeyValuePair<T>[]): Record<string, T>;

--- a/build/tradfri-client.d.ts
+++ b/build/tradfri-client.d.ts
@@ -5,7 +5,6 @@ import { Accessory } from "./lib/accessory";
 import { Group, GroupInfo, GroupOperation } from "./lib/group";
 import { LightOperation } from "./lib/light";
 import { LoggerFunction } from "./lib/logger";
-import { DictionaryLike } from "./lib/object-polyfill";
 import { OperationProvider } from "./lib/operation-provider";
 import { Scene } from "./lib/scene";
 export declare type ObserveResourceCallback = (resp: CoapResponse) => void;
@@ -44,9 +43,9 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
     /** dictionary of CoAP observers */
     observedPaths: string[];
     /** dictionary of known devices */
-    devices: DictionaryLike<Accessory>;
+    devices: Record<string, Accessory>;
     /** dictionary of known groups */
-    groups: DictionaryLike<GroupInfo>;
+    groups: Record<string, GroupInfo>;
     /** Base URL for all CoAP requests */
     private requestBase;
     /** Options regarding IPSO objects and serialization */

--- a/build/tradfri-client.d.ts
+++ b/build/tradfri-client.d.ts
@@ -35,6 +35,10 @@ export interface TradfriClient {
     removeListener(event: "error", callback: ErrorCallback): this;
     removeAllListeners(event?: ObservableEvents): this;
 }
+export interface TradfriOptions {
+    customLogger?: LoggerFunction;
+    useRawCoAPValues?: boolean;
+}
 export declare class TradfriClient extends EventEmitter implements OperationProvider {
     readonly hostname: string;
     /** dictionary of CoAP observers */
@@ -45,7 +49,11 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
     groups: DictionaryLike<GroupInfo>;
     /** Base URL for all CoAP requests */
     private requestBase;
-    constructor(hostname: string, customLogger?: LoggerFunction);
+    /** Options regarding IPSO objects and serialization */
+    private ipsoOptions;
+    constructor(hostname: string);
+    constructor(hostname: string, customLogger: LoggerFunction);
+    constructor(hostname: string, options: TradfriOptions);
     /**
      * Connect to the gateway
      * @param identity A previously negotiated identity.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-tradfri-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Library to talk to IKEA Trådfri Gateways without external binaries",
   "keywords": [
     "coap",

--- a/src/lib/accessory.ts
+++ b/src/lib/accessory.ts
@@ -20,7 +20,7 @@ export class Accessory extends IPSODevice {
 	public type: AccessoryTypes = AccessoryTypes.remote;
 
 	@ipsoKey("3")
-	@deserializeWith(obj => new DeviceInfo().parse(obj))
+	@deserializeWith((obj, me) => new DeviceInfo(me.options).parse(obj))
 	public deviceInfo: DeviceInfo = null;
 
 	@ipsoKey("9019")
@@ -30,19 +30,19 @@ export class Accessory extends IPSODevice {
 	public lastSeen: number = 0;
 
 	@ipsoKey("3311")
-	@deserializeWith((obj, me: Accessory) => new Light(me).parse(obj))
+	@deserializeWith((obj, me: Accessory) => new Light(me, me.options).parse(obj))
 	public lightList: Light[];
 
 	@ipsoKey("3312")
-	@deserializeWith(obj => new Plug().parse(obj))
+	@deserializeWith((obj, me) => new Plug(me.options).parse(obj))
 	public plugList: Plug[];
 
 	@ipsoKey("3300")
-	@deserializeWith(obj => new Sensor().parse(obj))
+	@deserializeWith((obj, me) => new Sensor(me.options).parse(obj))
 	public sensorList: Sensor[];
 
 	@ipsoKey("15009")
-	@deserializeWith(obj => new IPSODevice().parse(obj))
+	@deserializeWith((obj, me) => new IPSODevice(me.options).parse(obj))
 	public switchList: IPSODevice[]; // <[Switch]> // seems unsupported atm.
 
 	@ipsoKey("9054")
@@ -50,8 +50,8 @@ export class Accessory extends IPSODevice {
 
 	/**
 	 * Link this object to a TradfriClient for a simplified API.
-	 * INTERNAL USE ONLY!
 	 * @param client The client instance to link this object to
+	 * @internal
 	 */
 	public link(client: OperationProvider): this {
 		super.link(client);

--- a/src/lib/conversions.ts
+++ b/src/lib/conversions.ts
@@ -1,6 +1,6 @@
 // tslint:disable:variable-name
 
-import { PropertyTransform } from "./ipsoObject";
+import { PropertyTransformKernel } from "./ipsoObject";
 import { Light } from "./light";
 import { clamp, findClosestTriangleEdge, Point, pointInTriangle, projectPointOnEdge, roundTo } from "./math";
 import { colorTemperatureRange, MAX_COLOR } from "./predefined-colors";
@@ -10,14 +10,14 @@ import { padStart } from "./strings";
 // WHITE SPECTRUM conversions
 
 // interpolate from [0..100%] to [250..454]
-const colorTemperature_out: PropertyTransform = (value) => {
+const colorTemperature_out: PropertyTransformKernel = (value) => {
 	const [min, max] = colorTemperatureRange;
 	// extrapolate 0-100% to [min..max]
 	value = clamp(value, 0, 100);
 	return roundTo(min + value / 100 * (max - min), 0);
 };
 // interpolate from [250..454] to [0..100%]
-const colorTemperature_in: PropertyTransform = (value) => {
+const colorTemperature_in: PropertyTransformKernel = (value) => {
 	const [min, max] = colorTemperatureRange;
 	// interpolate "color percentage" from the colorTemperature range of a lightbulb
 	value = (value - min) / (max - min);
@@ -171,27 +171,27 @@ function rgbFromString(rgb: string) {
 // ===========================
 // RGB serializers
 // interpolate hue from [0..360] to [0..COLOR_MAX]
-const hue_out: PropertyTransform = (value, light: Light) => {
+const hue_out: PropertyTransformKernel = (value, light: Light) => {
 	if (light != null && light.spectrum !== "rgb") return null; // hue is not supported
 
 	value = clamp(value, 0, 360);
 	return roundTo(value / 360 * MAX_COLOR, 0);
 };
 // interpolate hue from [0..COLOR_MAX] to [0..360]
-const hue_in: PropertyTransform = (value /*, light: Light*/) => {
+const hue_in: PropertyTransformKernel = (value /*, light: Light*/) => {
 	value = clamp(value / MAX_COLOR, 0, 1);
 	return roundTo(value * 360, 0);
 };
 
 // interpolate saturation from [0..100%] to [0..COLOR_MAX]
-const saturation_out: PropertyTransform = (value, light: Light) => {
+const saturation_out: PropertyTransformKernel = (value, light: Light) => {
 	if (light != null && light.spectrum !== "rgb") return null; // hue is not supported
 
 	value = clamp(value, 0, 100);
 	return roundTo(value / 100 * MAX_COLOR, 0);
 };
 // interpolate saturation from [0..COLOR_MAX] to [0..100%]
-const saturation_in: PropertyTransform = (value /*, light: Light*/) => {
+const saturation_in: PropertyTransformKernel = (value /*, light: Light*/) => {
 	value = clamp(value / MAX_COLOR, 0, 1);
 	return roundTo(value * 100, 0);
 };
@@ -200,20 +200,20 @@ const saturation_in: PropertyTransform = (value /*, light: Light*/) => {
 // TRANSITION TIME conversions
 
 // the sent value is in 10ths of seconds, we're working with seconds
-const transitionTime_out: PropertyTransform = val => val * 10;
+const transitionTime_out: PropertyTransformKernel = val => val * 10;
 // the sent value is in 10ths of seconds, we're working with seconds
-const transitionTime_in: PropertyTransform = val => val / 10;
+const transitionTime_in: PropertyTransformKernel = val => val / 10;
 
 // ===========================
 // BRIGHTNESS conversions
 
 // interpolate from [0..100%] to [0..254]
-const brightness_out: PropertyTransform = (value) => {
+const brightness_out: PropertyTransformKernel = (value) => {
 	value = clamp(value, 0, 100);
 	return Math.round(value / 100 * 254);
 };
 // interpolate from [0..254] to [0..100%]
-const brightness_in: PropertyTransform = (value) => {
+const brightness_in: PropertyTransformKernel = (value) => {
 	value = clamp(value, 0, 254);
 	if (value === 0) return 0;
 	value = value / 254 * 100;

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -2,12 +2,11 @@ import { deserializers, serializers } from "./conversions";
 import { IPSODevice } from "./ipsoDevice";
 import { deserializeWith, ipsoKey, IPSOObject, PropertyTransform, required, serializeWith } from "./ipsoObject";
 import { clamp } from "./math";
-import { DictionaryLike } from "./object-polyfill";
 import { Scene } from "./scene";
 
 export interface GroupInfo {
 	group: Group;
-	scenes: DictionaryLike<Scene>;
+	scenes: Record<string, Scene>;
 }
 
 export class Group extends IPSODevice {
@@ -26,7 +25,7 @@ export class Group extends IPSODevice {
 
 	@ipsoKey("9018")
 	@deserializeWith(obj => parseAccessoryLink(obj))
-	@serializeWith(ids => toAccessoryLink(ids), false)
+	@serializeWith(ids => toAccessoryLink(ids), {splitArrays: false})
 	public deviceIDs: number[];
 
 	// The transition time is not reported by the gateway
@@ -35,8 +34,8 @@ export class Group extends IPSODevice {
 	// force transition time to be present if brightness is
 	// all other properties don't support the transition time
 	@required((me: Group, ref: Group) => ref != null && me.dimmer !== ref.dimmer)
-	@serializeWith(serializers.transitionTime)
-	@deserializeWith(deserializers.transitionTime)
+	@serializeWith(serializers.transitionTime, {neverSkip: true})
+	@deserializeWith(deserializers.transitionTime, {neverSkip: true})
 	public transitionTime: number; // <float>
 
 	// =================================

--- a/src/lib/ipsoObject.ts
+++ b/src/lib/ipsoObject.ts
@@ -1,5 +1,5 @@
 import { log } from "./logger";
-import { DictionaryLike, entries } from "./object-polyfill";
+import { entries } from "./object-polyfill";
 import { OperationProvider } from "./operation-provider";
 
 // ===========================================================
@@ -12,7 +12,32 @@ const METADATA_deserializeWith = Symbol("deserializeWith");
 const METADATA_doNotSerialize = Symbol("doNotSerialize");
 // tslint:enable:variable-name
 
-export type PropertyTransform = (value: any, parent?: IPSOObject) => any;
+export type PropertyTransformKernel = (value: any, parent?: IPSOObject) => any;
+export interface PropertyTransform extends PropertyTransformKernel {
+	/** If this transform is not supposed to be skipped ever */
+	neverSkip: boolean;
+	/** If this transform requires arrays to be split */
+	splitArrays: boolean;
+}
+/**
+ * Builds a property transform from a kernel and some options
+ * @param kernel The transform kernel
+ * @param options Some options regarding the property transform
+ */
+function buildPropertyTransform(
+	kernel: PropertyTransformKernel,
+	options: { splitArrays?: boolean, neverSkip?: boolean} = {},
+): PropertyTransform {
+
+	if (options.splitArrays == null) options.splitArrays = true;
+	if (options.neverSkip == null) options.neverSkip = false;
+
+	const ret = kernel as PropertyTransform;
+	ret.splitArrays = options.splitArrays;
+	ret.neverSkip = options.neverSkip;
+	return ret;
+}
+
 export type RequiredPredicate = (me: IPSOObject, reference: IPSOObject) => boolean;
 
 /**
@@ -81,26 +106,26 @@ function isRequired(target: object, reference: object, property: string | symbol
 /**
  * Defines the required transformations to serialize a property to a CoAP object
  * @param transform: The transformation to apply during serialization
- * @param splitArrays: Whether the serializer expects arrays to be split up in advance
+ * @param options: Some options regarding the behavior of the property transform
  */
-export const serializeWith = (transform: PropertyTransform, splitArrays: boolean = true): PropertyDecorator => {
+export function serializeWith(kernel: PropertyTransformKernel, options?: { splitArrays?: boolean, neverSkip?: boolean}): PropertyDecorator {
+	const transform = buildPropertyTransform(kernel, options);
 	return (target: object, property: string | symbol) => {
 		// get the class constructor
 		const constr = target.constructor;
 		// retrieve the current metadata
 		const metadata = Reflect.getMetadata(METADATA_serializeWith, constr) || {};
 
-		metadata[property] = {transform, splitArrays};
+		metadata[property] = transform;
 		// store back to the object
 		Reflect.defineMetadata(METADATA_serializeWith, metadata, constr);
 	};
-};
+}
 
-// tslint:disable:object-literal-key-quotes
-const defaultSerializers: DictionaryLike<PropertyTransform> = {
-	"Boolean": (bool: boolean) => bool ? 1 : 0,
+// default serializers should not be skipped
+const defaultSerializers: Record<string, PropertyTransform> = {
+	Boolean: buildPropertyTransform((bool: boolean) => bool ? 1 : 0, {neverSkip: true}),
 };
-// tslint:enable:object-literal-key-quotes
 
 /**
  * Retrieves the serializer for a given property
@@ -110,7 +135,7 @@ function getSerializer(target: object, property: string | symbol): PropertyTrans
 	const constr = target.constructor;
 	// retrieve the current metadata
 	const metadata = Reflect.getMetadata(METADATA_serializeWith, constr) || {};
-	if (metadata.hasOwnProperty(property)) return metadata[property].transform;
+	if (metadata.hasOwnProperty(property)) return metadata[property];
 	// If there's no custom serializer, try to find a default one
 	const type = getPropertyType(target, property);
 	if (type && type.name in defaultSerializers) {
@@ -119,40 +144,23 @@ function getSerializer(target: object, property: string | symbol): PropertyTrans
 }
 
 /**
- * Checks if the deserializer for a given property expects arrays to be split in advance
- */
-function serializerRequiresArraySplitting(target: object, property: string | symbol): boolean {
-	// get the class constructor
-	const constr = target.constructor;
-	// retrieve the current metadata
-	const metadata = Reflect.getMetadata(METADATA_serializeWith, constr) || {};
-
-	if (metadata.hasOwnProperty(property)) {
-		return metadata[property].splitArrays;
-	}
-	// return default value => true
-	return true;
-}
-
-/**
  * Defines the required transformations to deserialize a property from a CoAP object
  * @param transform: The transformation to apply during deserialization
  * @param splitArrays: Whether the deserializer expects arrays to be split up in advance
  */
-export const deserializeWith = (transforms: PropertyTransform | PropertyTransform[], splitArrays: boolean = true): PropertyDecorator => {
-	// make sure we have an array of transforms
-	if (!(transforms instanceof Array)) transforms = [transforms];
+export function deserializeWith(kernel: PropertyTransformKernel, options?: { splitArrays?: boolean, neverSkip?: boolean}): PropertyDecorator {
+	const transform = buildPropertyTransform(kernel, options);
 	return (target: object, property: string | symbol) => {
 		// get the class constructor
 		const constr = target.constructor;
 		// retrieve the current metadata
 		const metadata = Reflect.getMetadata(METADATA_deserializeWith, constr) || {};
 
-		metadata[property] = {transforms, splitArrays};
+		metadata[property] = transform;
 		// store back to the object
 		Reflect.defineMetadata(METADATA_deserializeWith, metadata, constr);
 	};
-};
+}
 
 /**
  * Defines that a property will not be serialized
@@ -179,56 +187,28 @@ function isSerializable(target: object, property: string | symbol): boolean {
 	return ! metadata.hasOwnProperty(property);
 }
 
-// tslint:disable:object-literal-key-quotes
-const defaultDeserializers: DictionaryLike<PropertyTransform> = {
-	"Boolean": (raw: any) => raw === 1 || raw === "true" || raw === "on" || raw === true,
+// default deserializers should not be skipped
+const defaultDeserializers: Record<string, PropertyTransform> = {
+	Boolean: buildPropertyTransform((raw: any) => raw === 1 || raw === "true" || raw === "on" || raw === true, {neverSkip: true}),
 };
-// tslint:enable:object-literal-key-quotes
 
 /**
  * Retrieves the deserializer for a given property
  */
-function getDeserializers(target: object, property: string | symbol): PropertyTransform[] {
+function getDeserializer(target: object, property: string | symbol): PropertyTransform {
 	// get the class constructor
 	const constr = target.constructor;
 	// retrieve the current metadata
 	const metadata = Reflect.getMetadata(METADATA_deserializeWith, constr) || {};
 
 	if (metadata.hasOwnProperty(property)) {
-		return metadata[property].transforms;
+		return metadata[property];
 	}
 	// If there's no custom deserializer, try to find a default one
 	const type = getPropertyType(target, property);
 	if (type && type.name in defaultDeserializers) {
-		return [defaultDeserializers[type.name]];
+		return defaultDeserializers[type.name];
 	}
-}
-
-/**
- * Apply a series of deserializers in the defined order. The first one returning a value != null wins
- */
-function applyDeserializers(deserializers: PropertyTransform[], target: any, parent?: IPSOObject): any {
-	for (const d of deserializers) {
-		const ret = d(target, parent);
-		if (ret != null) return ret;
-	}
-	return null;
-}
-
-/**
- * Checks if the deserializer for a given property expects arrays to be split in advance
- */
-function deserializerRequiresArraySplitting(target: object, property: string | symbol): boolean {
-	// get the class constructor
-	const constr = target.constructor;
-	// retrieve the current metadata
-	const metadata = Reflect.getMetadata(METADATA_deserializeWith, constr) || {};
-
-	if (metadata.hasOwnProperty(property)) {
-		return metadata[property].splitArrays;
-	}
-	// return default value => true
-	return true;
 }
 
 /**
@@ -257,10 +237,10 @@ interface ProxiedIPSOObject<T extends IPSOObject> extends IPSOObject {
  * Provides a set of options regarding IPSO objects and serialization
  */
 export interface IPSOOptions {
-	/** 
-	 * Determines if basic serializers (i.e. for simple values) should be skipped 
+	/**
+	 * Determines if basic serializers (i.e. for simple values) should be skipped
 	 * This is used to support raw CoAP values instead of the simplified scales
-	 * */
+	 */
 	skipBasicSerializers?: boolean;
 }
 
@@ -271,7 +251,7 @@ export class IPSOObject {
 	 * Internal options regarding serialization
 	 * @internal
 	 */
-	@doNotSerialize 
+	@doNotSerialize
 	public options: IPSOOptions;
 
 	constructor(options: IPSOOptions = {}) {
@@ -281,13 +261,12 @@ export class IPSOObject {
 	/**
 	 * Reads this instance's properties from the given object
 	 */
-	public parse(obj: DictionaryLike<any>): this {
+	public parse(obj: Record<string, any>): this {
 		for (const [key, value] of entries(obj)) {
-			let deserializers: PropertyTransform[] = getDeserializers(this, key);
-			let requiresArraySplitting: boolean = deserializerRequiresArraySplitting(this, key);
+			let deserializer: PropertyTransform = getDeserializer(this, key);
 			// key might be ipso key or property name
 			let propName: string | symbol;
-			if (deserializers == null) {
+			if (deserializer == null) {
 				// deserializers are defined by property name, so key is actually the key
 				propName = lookupKeyOrProperty(this, key);
 				if (!propName) {
@@ -295,14 +274,14 @@ export class IPSOObject {
 					log(`object was: ${JSON.stringify(obj)}`, "warn");
 					continue;
 				}
-				deserializers = getDeserializers(this, propName);
-				requiresArraySplitting = deserializerRequiresArraySplitting(this, propName);
+				deserializer = getDeserializer(this, propName);
 			} else {
 				// the deserializer was found, so key is actually the property name
 				propName = key;
 			}
 			// parse the value
-			const parsedValue = this.parseValue(key, value, deserializers, requiresArraySplitting);
+			const requiresArraySplitting: boolean = deserializer ? deserializer.splitArrays : true;
+			const parsedValue = this.parseValue(key, value, deserializer, requiresArraySplitting);
 			// and remember it
 			this[propName] = parsedValue;
 		}
@@ -310,20 +289,19 @@ export class IPSOObject {
 	}
 
 	// parses a value, depending on the value type and defined parsers
-	private parseValue(propKey, value, deserializers?: PropertyTransform[], requiresArraySplitting: boolean = true): any {
+	private parseValue(propKey, value, transform?: PropertyTransform, requiresArraySplitting: boolean = true): any {
 		if (value instanceof Array && requiresArraySplitting) {
 			// Array: parse every element
-			return value.map(v => this.parseValue(propKey, v, deserializers, requiresArraySplitting));
+			return value.map(v => this.parseValue(propKey, v, transform, requiresArraySplitting));
 		} else if (typeof value === "object") {
 			// Object: try to parse this, objects should be parsed in any case
-			if (deserializers) {
-				return applyDeserializers(deserializers, value, this);
+			if (transform) {
+				return transform(value, this);
 			} else {
 				log(`could not find deserializer for key ${propKey}`, "warn");
 			}
-		} else if (deserializers && !this.options.skipBasicSerializers) {
-			// if this property needs a parser, parse the value
-			return applyDeserializers(deserializers, value, this);
+		} else if (transform && (transform.neverSkip || !this.options.skipBasicSerializers)) {
+			return transform(value, this);
 		} else {
 			// otherwise just return the value
 			return value;
@@ -334,7 +312,7 @@ export class IPSOObject {
 	 * Overrides this object's properties with those from another partial one
 	 */
 	public merge(obj: Partial<this>): this {
-		for (const [key, value] of entries(obj as DictionaryLike<any>)) {
+		for (const [key, value] of entries(obj as Record<string, any>)) {
 			if (this.hasOwnProperty(key)) {
 				this[key] = value;
 			}
@@ -343,7 +321,7 @@ export class IPSOObject {
 	}
 
 	/** serializes this object in order to transfer it via COAP */
-	public serialize(reference = null): DictionaryLike<any> {
+	public serialize(reference = null): Record<string, any> {
 		// unproxy objects before serialization
 		if (this.isProxy) return this.unproxy().serialize(reference);
 		if (
@@ -370,7 +348,9 @@ export class IPSOObject {
 					// there is no default value, just remember the actual value
 				}
 			}
-			if (transform && !this.options.skipBasicSerializers) _ret = transform(_ret, this);
+			if (transform && (transform.neverSkip || !this.options.skipBasicSerializers)) {
+				_ret = transform(_ret, this);
+			}
 			return _ret;
 		};
 
@@ -396,7 +376,7 @@ export class IPSOObject {
 
 				// try to find serializer for this property
 				const serializer = getSerializer(this, propName);
-				const requiresArraySplitting: boolean = serializerRequiresArraySplitting(this, propName);
+				const requiresArraySplitting = serializer ? serializer.splitArrays : true;
 
 				if (value instanceof Array && requiresArraySplitting) {
 					// serialize each item
@@ -443,7 +423,7 @@ export class IPSOObject {
 		return (ret as IPSOObject).parse(serialized) as this;
 	}
 
-	private isSerializedObjectEmpty(obj: DictionaryLike<any>, refObj: DictionaryLike<any>): boolean {
+	private isSerializedObjectEmpty(obj: Record<string, any>, refObj: Record<string, any>): boolean {
 		// Prüfen, ob eine nicht-benötigte Eigenschaft angegeben ist. => nicht leer
 		for (const key of Object.keys(obj)) {
 			const propName = lookupKeyOrProperty(this, key);

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -1,7 +1,7 @@
 import { Accessory } from "./accessory";
 import { conversions, deserializers, serializers } from "./conversions";
 import { IPSODevice } from "./ipsoDevice";
-import { deserializeWith, doNotSerialize, ipsoKey, PropertyTransform, required, serializeWith, IPSOOptions } from "./ipsoObject";
+import { deserializeWith, doNotSerialize, ipsoKey, IPSOOptions, PropertyTransform, required, serializeWith } from "./ipsoObject";
 import { clamp } from "./math";
 import { MAX_COLOR, predefinedColors, whiteSpectrumHex } from "./predefined-colors";
 
@@ -73,8 +73,8 @@ export class Light extends IPSODevice {
 
 	@ipsoKey("5712")
 	@required()
-	@serializeWith(serializers.transitionTime)
-	@deserializeWith(deserializers.transitionTime)
+	@serializeWith(serializers.transitionTime, {neverSkip: true})
+	@deserializeWith(deserializers.transitionTime, {neverSkip: true})
 	public transitionTime: number = 0.5; // <float>
 
 	@ipsoKey("5805")

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -1,7 +1,7 @@
 import { Accessory } from "./accessory";
 import { conversions, deserializers, serializers } from "./conversions";
 import { IPSODevice } from "./ipsoDevice";
-import { deserializeWith, doNotSerialize, ipsoKey, PropertyTransform, required, serializeWith } from "./ipsoObject";
+import { deserializeWith, doNotSerialize, ipsoKey, PropertyTransform, required, serializeWith, IPSOOptions } from "./ipsoObject";
 import { clamp } from "./math";
 import { MAX_COLOR, predefinedColors, whiteSpectrumHex } from "./predefined-colors";
 
@@ -16,8 +16,8 @@ export type LightOperation = Partial<Pick<Light,
 
 export class Light extends IPSODevice {
 
-	constructor(accessory?: Accessory) {
-		super();
+	constructor(accessory?: Accessory, options?: IPSOOptions) {
+		super(options);
 
 		// In order for the simplified API to work, the
 		// accessory reference must be a proxy

--- a/src/lib/lightSetting.ts
+++ b/src/lib/lightSetting.ts
@@ -8,9 +8,9 @@ export class LightSetting extends IPSODevice {
 	public color: string = "f1e0b5"; // hex string
 
 	@ipsoKey("5707")
-	public hue: number = 0; // TODO: TODO: range unknown! [0-359]?
+	public hue: number = 0; // [0-359]
 	@ipsoKey("5708")
-	public saturation: number = 0; // TODO: range unknown!
+	public saturation: number = 0; // [0..100%]
 
 	@ipsoKey("5709")
 	public colorX: number = 0; // int

--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -1,6 +1,5 @@
 import { IPSODevice } from "./ipsoDevice";
 import { deserializeWith, ipsoKey, IPSOObject, PropertyTransform, required, serializeWith } from "./ipsoObject";
-import { DictionaryLike } from "./object-polyfill";
 
 export class Notification extends IPSODevice {
 
@@ -8,8 +7,8 @@ export class Notification extends IPSODevice {
 	public event: NotificationTypes = 0;
 
 	@ipsoKey("9017")
-	@deserializeWith(arr => parseNotificationDetails(arr), false /* parse whole arrays */)
-	public details: DictionaryLike<string> = {};
+	@deserializeWith(arr => parseNotificationDetails(arr), {splitArrays: false})
+	public details: Record<string, string> = {};
 
 	@ipsoKey("9014")
 	public state: number = 0; // => ?
@@ -27,7 +26,7 @@ export enum NotificationTypes {
 /**
  * Turns a key=value-Array into a Dictionary object
  */
-function parseNotificationDetails(kvpList: string[]): DictionaryLike<string> {
+function parseNotificationDetails(kvpList: string[]): Record<string, string> {
 	const ret = {};
 	for (const kvp of kvpList) {
 		const parts = kvp.split("=");

--- a/src/lib/object-polyfill.ts
+++ b/src/lib/object-polyfill.ts
@@ -1,6 +1,3 @@
-export interface DictionaryLike<T> {
-	[key: string]: T;
-}
 export type Predicate<T> = (value: T) => boolean;
 export type KeyValuePair<T> = [string, T];
 
@@ -8,7 +5,7 @@ export type KeyValuePair<T> = [string, T];
  * Stellt einen Polyfill für Object.entries bereit
  * @param obj Das Objekt, dessen Eigenschaften als Key-Value-Pair iteriert werden sollen
  */
-export function entries<T>(obj: DictionaryLike<T>): KeyValuePair<T>[];
+export function entries<T>(obj: Record<string, T>): KeyValuePair<T>[];
 export function entries(obj: any): KeyValuePair<any>[] {
 	return Object.keys(obj)
 		.map(key => [key, obj[key]] as KeyValuePair<any>)
@@ -20,7 +17,7 @@ export function entries(obj: any): KeyValuePair<any>[] {
  * Stellt einen Polyfill für Object.values bereit
  * @param obj Das Objekt, dessen Eigenschaftswerte iteriert werden sollen
  */
-export function values<T>(obj: DictionaryLike<T>): T[];
+export function values<T>(obj: Record<string, T>): T[];
 export function values(obj): any[] {
 	return Object.keys(obj)
 		.map(key => obj[key])
@@ -32,7 +29,7 @@ export function values(obj): any[] {
  * @param obj Das Objekt, dessen Eigenschaften gefiltert werden sollen
  * @param predicate Die Filter-Funktion, die auf Eigenschaften angewendet wird
  */
-export function filter<T>(obj: DictionaryLike<T>, predicate: Predicate<T>): DictionaryLike<T>;
+export function filter<T>(obj: Record<string, T>, predicate: Predicate<T>): Record<string, T>;
 export function filter(obj: any, predicate: Predicate<any>) {
 	const ret = {};
 	for (const [key, val] of entries(obj)) {
@@ -45,8 +42,8 @@ export function filter(obj: any, predicate: Predicate<any>) {
  * Kombinierte mehrere Key-Value-Paare zu einem Objekt
  * @param properties Die Key-Value-Paare, die zu einem Objekt kombiniert werden sollen
  */
-export function composeObject<T>(properties: KeyValuePair<T>[]): DictionaryLike<T>;
-export function composeObject(properties: KeyValuePair<any>[]): DictionaryLike<any> {
+export function composeObject<T>(properties: KeyValuePair<T>[]): Record<string, T>;
+export function composeObject(properties: KeyValuePair<any>[]): Record<string, any> {
 	return properties.reduce((acc, [key, value]) => {
 		acc[key] = value;
 		return acc;

--- a/src/tradfri-client.test.ts
+++ b/src/tradfri-client.test.ts
@@ -11,7 +11,7 @@ import { ContentFormats } from "node-coap-client/build/ContentFormats";
 import { MessageCode } from "node-coap-client/build/Message";
 import * as sinonChai from "sinon-chai";
 import { Accessory } from "./lib/accessory";
-import { DictionaryLike } from "./lib/object-polyfill";
+import { padStart } from "./lib/strings";
 
 // enable the should interface with sinon
 should();
@@ -23,14 +23,14 @@ describe("tradfri-client => ", () => {
 
 	const devicesUrl = `coaps://localhost:5684/15001`;
 
-	const fakeCoap: DictionaryLike<sinon.SinonStub> = {
+	const fakeCoap: Record<string, sinon.SinonStub> = {
 		observe: null,
 		request: null,
 		stopObserving: null,
 		reset: null,
 	};
 	let observeDevices_callback: (response: CoapResponse) => Promise<void>;
-	const observeDevice_callbacks: DictionaryLike<(response: CoapResponse) => Promise<void>> = {};
+	const observeDevice_callbacks: Record<string, (response: CoapResponse) => Promise<void>> = {};
 	const emptyAccessory = new Accessory().serialize();
 	/**
 	 * Remembers a callback for later tests
@@ -213,3 +213,48 @@ describe("tradfri-client => ", () => {
 	});
 
 });
+
+// function dump(obj: object, propName: string = null, indent: number = 0) {
+// 	if (obj == null) return;
+// 	if (propName == null) {
+// 		console.log(padStart("", indent * 4) + "{");
+// 	} else {
+// 		console.log(padStart("", indent * 4) + propName + ": {");
+// 	}
+// 	for (const key of Object.keys(obj)) {
+// 		if (key.startsWith("_")) continue;
+// 		const val = obj[key];
+// 		if (typeof val === "object") {
+// 			dump(val, key, indent + 1);
+// 		} else {
+// 			console.log(padStart("", (indent + 1) * 4) + `${key}: ${JSON.stringify(val)}`);
+// 		}
+// 	}
+// 	console.log(padStart("", indent * 4) + "}");
+// }
+
+// // tslint:disable-next-line:only-arrow-functions
+// describe.only("raw coap tests => ", function() {
+// 	const params = {host: "gw-b072bf257a41", securityCode: "", identity: "tradfri_1509642359115", psk: "gzqZY5HUlFOOVu9f"};
+// 	const tradfri = new TradfriClient(params.host, {useRawCoAPValues: true});
+// 	this.timeout(60000);
+// 	it("should work", async () => {
+// 		await tradfri.connect(params.identity, params.psk);
+
+// 		const devices = new Map<number, Accessory>();
+
+// 		tradfri.on("device updated", (acc) => {
+// 			devices.set(acc.instanceId, acc);
+// 			console.log("===================");
+// 			console.log("got device: ");
+// 			dump(acc);
+// 		});
+// 		await tradfri.observeDevices();
+
+// 		const light = devices.get(65537).lightList[0];
+// 		console.log("GOGOGO!");
+// 		await tradfri.operateLight(devices.get(65537), {
+// 			onOff: false,
+// 		});
+// 	});
+// });

--- a/src/tradfri-client.ts
+++ b/src/tradfri-client.ts
@@ -11,7 +11,6 @@ import { Group, GroupInfo, GroupOperation } from "./lib/group";
 import { IPSOObject, IPSOOptions } from "./lib/ipsoObject";
 import { LightOperation } from "./lib/light";
 import { log, LoggerFunction, setCustomLogger } from "./lib/logger";
-import { DictionaryLike } from "./lib/object-polyfill";
 import { OperationProvider } from "./lib/operation-provider";
 import { Scene } from "./lib/scene";
 import { TradfriError, TradfriErrorCodes } from "./lib/tradfri-error";
@@ -58,8 +57,8 @@ export declare interface TradfriClient {
 }
 
 export interface TradfriOptions {
-	customLogger?: LoggerFunction,
-	useRawCoAPValues?: boolean,
+	customLogger?: LoggerFunction;
+	useRawCoAPValues?: boolean;
 }
 
 export class TradfriClient extends EventEmitter implements OperationProvider {
@@ -67,9 +66,9 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	/** dictionary of CoAP observers */
 	public observedPaths: string[] = [];
 	/** dictionary of known devices */
-	public devices: DictionaryLike<Accessory> = {};
+	public devices: Record<string, Accessory> = {};
 	/** dictionary of known groups */
-	public groups: DictionaryLike<GroupInfo> = {};
+	public groups: Record<string, GroupInfo> = {};
 
 	/** Base URL for all CoAP requests */
 	private requestBase: string;
@@ -86,7 +85,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	) {
 		super();
 		this.requestBase = `coaps://${hostname}:5684/`;
-		
+
 		if (optionsOrLogger != null) {
 			if (typeof optionsOrLogger === "function") {
 				// Legacy version: 2nd parameter is a logger


### PR DESCRIPTION
Adds an option to `TradfriClient` which enables the use of raw CoAP values instead of the internal scales.

Untested!