### PR TITLE
Swallow `"DTLS handshake timed out"` promise rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ if (e instanceof TradfriError) {
 ```
 The currently supported error codes are:
 * `TradfriErrorCode.NetworkReset`: The `reset()` method was called while some requests or connection attempts were still pending. Those promises will not be fulfilled anymore, and you should delete all references to them.
+* `TradfriErrorCode.ConnectionTimedOut`: While some requests or connection attempts were still pending, a secure connection could not be established within the timeout. The promises related to those requests or connection attempts will not be fulfilled anymore, and you should delete all references to them.
 
 ### Observe a resource
 The standard way to receive updates to a Trådfri (or CoAP) resource is by observing it. The TradfriClient provides a couple of methods to observe resources, with the most generic one being
@@ -505,6 +506,9 @@ A DeviceInfo object contains general information about a device. It has the foll
 * `serialNumber: string` - Not used currently. Always `""`
 
 ## Changelog
+
+#### __WORK IN PROGRESS__
+* (AlCalzone) Swallow `"DTLS handshake timed out"` promise rejections and emit an `"error"` instead
 
 #### 0.10.1 (2018-03-15)
 * (AlCalzone) Ensure all changes are being sent when using the simplified API for groups.

--- a/build/lib/tradfri-error.d.ts
+++ b/build/lib/tradfri-error.d.ts
@@ -1,7 +1,8 @@
 export declare enum TradfriErrorCodes {
     ConnectionFailed = 0,
-    AuthenticationFailed = 1,
-    NetworkReset = 2,
+    ConnectionTimedOut = 1,
+    AuthenticationFailed = 2,
+    NetworkReset = 3,
 }
 export declare class TradfriError extends Error {
     readonly message: string;

--- a/build/lib/tradfri-error.js
+++ b/build/lib/tradfri-error.js
@@ -3,8 +3,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var TradfriErrorCodes;
 (function (TradfriErrorCodes) {
     TradfriErrorCodes[TradfriErrorCodes["ConnectionFailed"] = 0] = "ConnectionFailed";
-    TradfriErrorCodes[TradfriErrorCodes["AuthenticationFailed"] = 1] = "AuthenticationFailed";
-    TradfriErrorCodes[TradfriErrorCodes["NetworkReset"] = 2] = "NetworkReset";
+    TradfriErrorCodes[TradfriErrorCodes["ConnectionTimedOut"] = 1] = "ConnectionTimedOut";
+    TradfriErrorCodes[TradfriErrorCodes["AuthenticationFailed"] = 2] = "AuthenticationFailed";
+    TradfriErrorCodes[TradfriErrorCodes["NetworkReset"] = 3] = "NetworkReset";
 })(TradfriErrorCodes = exports.TradfriErrorCodes || (exports.TradfriErrorCodes = {}));
 class TradfriError extends Error {
     constructor(message, code) {

--- a/build/tradfri-client.js
+++ b/build/tradfri-client.js
@@ -626,6 +626,10 @@ class TradfriClient extends events_1.EventEmitter {
                     // inform the user about what happened.
                     this.emit("error", new tradfri_error_1.TradfriError("The network stack was reset. Pending promises will not be fulfilled.", tradfri_error_1.TradfriErrorCodes.NetworkReset));
                 }
+                else if (/dtls handshake timed out/i.test(e.message)) {
+                    // The DTLS layer did not complete a handshake in time.
+                    this.emit("error", new tradfri_error_1.TradfriError("Could not establish a secure connection in time. Pending promises will not be fulfilled.", tradfri_error_1.TradfriErrorCodes.ConnectionTimedOut));
+                }
                 else {
                     reject(e);
                 }

--- a/maintenance/release.ts
+++ b/maintenance/release.ts
@@ -17,6 +17,7 @@ import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as readline from "readline";
+import { padStart } from "../src/lib/strings";
 const semver = require("semver");
 const colors = require("colors/safe");
 import { argv } from "yargs";
@@ -25,6 +26,8 @@ const rootDir = path.resolve(__dirname, "../");
 
 const packPath = path.join(rootDir, "package.json");
 const pack = require(packPath);
+const readmePath = path.join(rootDir, "README.md");
+let readme = fs.readFileSync(readmePath, "utf8");
 // const ioPackPath = path.join(rootDir, "io-package.json");
 // const ioPack = require(ioPackPath);
 
@@ -87,6 +90,14 @@ if (argv.dry) {
 	console.log(`updating package.json from ${colors.blue(pack.version)} to ${colors.green(newVersion)}`);
 	pack.version = newVersion;
 	fs.writeFileSync(packPath, JSON.stringify(pack, null, 2));
+
+	console.log(`updating changelog in README.md`);
+	const d = new Date();
+	readme = readme.replace(
+		"#### __WORK IN PROGRESS__",
+		`#### ${newVersion} (${d.getFullYear()}-${padStart("" + d.getMonth() + 1, 2, "0")}-${padStart("" + d.getDay(), 2, "0")})`,
+	);
+	fs.writeFileSync(readmePath, readme, "utf8");
 
 	// console.log(`updating io-package.json from ${colors.blue(ioPack.common.version)} to ${colors.green(newVersion)}`);
 	// ioPack.common.version = newVersion;

--- a/src/lib/tradfri-error.ts
+++ b/src/lib/tradfri-error.ts
@@ -1,5 +1,6 @@
 export enum TradfriErrorCodes {
 	ConnectionFailed,
+	ConnectionTimedOut,
 	AuthenticationFailed,
 	NetworkReset,
 }

--- a/src/tradfri-client.test.ts
+++ b/src/tradfri-client.test.ts
@@ -641,5 +641,20 @@ describe("tradfri-client => custom requests => ", () => {
 
 			tradfri.request(null, null);
 		});
+
+		it("when the DTLS handshake times out during a pending request, the rejection should be turned into an error event", (done) => {
+			fakeCoap.request.returns(Promise.reject(new Error("The DTLS handshake timed out")));
+
+			tradfri.on("error", err => {
+				err.should.be.an.instanceof(TradfriError);
+				(err as TradfriError).code.should.equal(TradfriErrorCodes.ConnectionTimedOut);
+
+				tradfri.removeAllListeners();
+				fakeCoap.request.resetBehavior();
+				done();
+			});
+
+			tradfri.request(null, null);
+		});
 	});
 });

--- a/src/tradfri-client.ts
+++ b/src/tradfri-client.ts
@@ -801,6 +801,12 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 						"The network stack was reset. Pending promises will not be fulfilled.",
 						TradfriErrorCodes.NetworkReset,
 					));
+				} else if (/dtls handshake timed out/i.test(e.message)) {
+					// The DTLS layer did not complete a handshake in time.
+					this.emit("error", new TradfriError(
+						"Could not establish a secure connection in time. Pending promises will not be fulfilled.",
+						TradfriErrorCodes.ConnectionTimedOut,
+					));
 				} else {
 					reject(e);
 				}


### PR DESCRIPTION
and emit an `"error"` instead. Fixes #45.