### PR TITLE
Determine spectrum based on available properties instead of model name

### DIFF
--- a/src/lib/light.test.ts
+++ b/src/lib/light.test.ts
@@ -19,7 +19,7 @@ import { MAX_COLOR, predefinedColors, whiteSpectrumHex } from "./predefined-colo
 should();
 
 function buildAccessory(modelName: string, spectrum: Spectrum) {
-	let attributes = {
+	const attributes = {
 		3: {
 			0: "IKEA of Sweden",
 			1: modelName,
@@ -45,15 +45,17 @@ function buildAccessory(modelName: string, spectrum: Spectrum) {
 		9020: 1507456927,
 		9054: 0,
 	};
-	
-	switch(spectrum) {
+
+	switch (spectrum) {
 		case "rgb": {
 			attributes["3311"][0]["5707"] = 38079;
-			attributes["3311"][0]["5708"] = 43737; 
-			attributes["3311"][0]["5711"] = 0; 
+			attributes["3311"][0]["5708"] = 43737;
+			attributes["3311"][0]["5711"] = 0;
+			break;
 		}
 		case "white": {
-			attributes["3311"][0]["5711"] = 0; 
+			attributes["3311"][0]["5711"] = 0;
+			break;
 		}
 	}
 	return attributes;

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -129,15 +129,14 @@ export class Light extends IPSODevice {
 	public get spectrum(): Spectrum {
 		if (this._spectrum == null) {
 			// determine the spectrum
-			this._spectrum = "none";
-			if (this._modelName != null) {
-				if (this._modelName.indexOf(" WS ") > -1) {
-					// WS = white spectrum
-					this._spectrum = "white";
-				} else if (this._modelName.indexOf(" C/WS ") > -1 || this._modelName.indexOf(" CWS ") > -1) {
-					// CWS = color + white spectrum
-					this._spectrum = "rgb";
-				}
+			if (this.hue != null && this.saturation != null) {
+				this._spectrum = "rgb";
+			}
+			else if (this.colorTemperature != null) {
+				this._spectrum = "white";
+			}
+			else {
+				this._spectrum = "none";
 			}
 		}
 		return this._spectrum;

--- a/src/lib/light.ts
+++ b/src/lib/light.ts
@@ -131,11 +131,9 @@ export class Light extends IPSODevice {
 			// determine the spectrum
 			if (this.hue != null && this.saturation != null) {
 				this._spectrum = "rgb";
-			}
-			else if (this.colorTemperature != null) {
+			} else if (this.colorTemperature != null) {
 				this._spectrum = "white";
-			}
-			else {
+			} else {
 				this._spectrum = "none";
 			}
 		}


### PR DESCRIPTION
This is the most simple fix I could think of.

Notes:

- At least for Hue lamps there seem to be white spectrum, color lamps and extended color lamps (with white spectrum and color). Since rgb covers the whole range of colors, white colors will just not look that good on rgb-only lamps not containing  white leds, but I don't see a reason to add an extra spectrum option to reflect this difference, unless you really can't set color temperature on a color-only lamp.

- the build folder is on github, but excluded in .gitignore, I didn't include it.

- know I will not be offended if you reject the pull request and solve the issue in another way :)