### PR TITLE
Add AccessoryTypes.extraRemote

### DIFF
--- a/src/lib/accessory.ts
+++ b/src/lib/accessory.ts
@@ -9,6 +9,7 @@ import { Sensor } from "./sensor";
 // list of known endpoints defined on the gateway
 export enum AccessoryTypes {
 	remote = 0,
+	extraRemote = 1, // i.e. remote which has been paired with another remote (https://www.reddit.com/r/tradfri/comments/6x1miq)
 	lightbulb = 2,
 	plug = 3,
 	motionSensor = 4,


### PR DESCRIPTION
Thanks for your great work on `node-tradfri-client`, it's a joy to use!

I have a group which has been set up with 2 remotes, for a room which you can enter via 2 entrances, as per the [semi-official procedure](https://www.reddit.com/r/tradfri/comments/6x1miq/). I noticed that such remote controllers are reported with their own type number:

```
>>> console.log({ ...remote, client: null });
{ isProxy: true,
  options: {},
  name: 'Bathroom secondary',
  createdAt: 1539718471,
  instanceId: 65581,
  type: 1,
  alive: true,
  lastSeen: 1541186692,
  otaUpdateState: 0,
  deviceInfo:
   DeviceInfo {
     isProxy: false,
     options: {},
     firmwareVersion: '1.2.214',
     manufacturer: 'IKEA of Sweden',
     modelNumber: 'TRADFRI remote control',
     power: 3,
     serialNumber: '',
     battery: 87 },
  client: null }
```

Not 100% sure how it should be handled internally, because in every other way it seems to work just like any other remote, but I think adding it to the enum would be a start.