### PR TITLE
 Add `force` parameter to `operateXYZ` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## __WORK_IN_PROGRESS__
+* (AlCalzone) Add a third parameter (`force`) to `operateLight`, `operatePlug` and `operateBlind` methods
+
 ## 2.0.1 (2019-09-22)
 * (AlCalzone) BREAKING: The position of blinds has been inverted. 0 now means closed, 100 means open.
 * (AlCalzone) Add the `position` property and `setPosition` method to `Group`

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ If the accessory object is not changed in comparison to the one on the gateway, 
 **NOTE:** To switch a light on/off or to change its properties, prefer the `operateLight` method or the specialized methods defined on the lightbulb itself.
 
 ```TS
-const requestSent = await tradfri.operateLight(accessory: Accessory, operation: LightOperation);
+const requestSent = await tradfri.operateLight(accessory: Accessory, operation: LightOperation[, force: boolean]);
 ```
 The parameter `accessory` is the device containing the lightbulb. The `operation` object contains the properties to be updated, e.g.
 ```TS
@@ -464,6 +464,7 @@ The parameter `accessory` is the device containing the lightbulb. The `operation
     transitionTime: 5,
 }
 ```
+By setting the optional third parameter (`force`) to true, the entire `operation` object will be transmitted, even if no values have changed.
 
 ### Updating a group on the gateway
 Similar to updating devices, you can update groups by calling

--- a/build/lib/blind.d.ts
+++ b/build/lib/blind.d.ts
@@ -10,11 +10,11 @@ export declare class Blind extends IPSODevice {
     /**
      * Returns true if the current blind is dimmable
      */
-    readonly isDimmable: boolean;
+    get isDimmable(): boolean;
     /**
      * Returns true if the current blind is switchable
      */
-    readonly isSwitchable: boolean;
+    get isSwitchable(): boolean;
     clone(): this;
     /**
      * Creates a proxy which redirects the properties to the correct internal one, does nothing now

--- a/build/lib/light.d.ts
+++ b/build/lib/light.d.ts
@@ -22,17 +22,17 @@ export declare class Light extends IPSODevice {
     /**
      * Returns true if the current lightbulb is dimmable
      */
-    readonly isDimmable: boolean;
+    get isDimmable(): boolean;
     /**
      * Returns true if the current lightbulb is switchable
      */
-    readonly isSwitchable: boolean;
+    get isSwitchable(): boolean;
     clone(): this;
     /**
      * Returns the supported color spectrum of the lightbulb
      */
     private _spectrum;
-    readonly spectrum: Spectrum;
+    get spectrum(): Spectrum;
     /**
      * Creates a proxy which redirects the properties to the correct internal one
      */

--- a/build/lib/notification.d.ts
+++ b/build/lib/notification.d.ts
@@ -4,7 +4,7 @@ export declare class Notification extends IPSOObject {
     timestamp: number;
     event: NotificationTypes;
     private _details;
-    readonly details: NotificationDetails;
+    get details(): NotificationDetails;
     isActive: boolean;
     toJSON(): {
         timestamp: number;

--- a/build/lib/operation-provider.d.ts
+++ b/build/lib/operation-provider.d.ts
@@ -5,7 +5,7 @@ import { LightOperation } from "./light";
 import { PlugOperation } from "./plug";
 export interface OperationProvider {
     operateGroup(group: Group, operation: GroupOperation, force?: boolean): Promise<boolean>;
-    operateLight(accessory: Accessory, operation: LightOperation): Promise<boolean>;
-    operatePlug(accessory: Accessory, operation: PlugOperation): Promise<boolean>;
-    operateBlind(accessory: Accessory, operation: BlindOperation): Promise<boolean>;
+    operateLight(accessory: Accessory, operation: LightOperation, force?: boolean): Promise<boolean>;
+    operatePlug(accessory: Accessory, operation: PlugOperation, force?: boolean): Promise<boolean>;
+    operateBlind(accessory: Accessory, operation: BlindOperation, force?: boolean): Promise<boolean>;
 }

--- a/build/lib/plug.d.ts
+++ b/build/lib/plug.d.ts
@@ -14,11 +14,11 @@ export declare class Plug extends IPSODevice {
     /**
      * Returns true if the current plug is dimmable
      */
-    readonly isDimmable: boolean;
+    get isDimmable(): boolean;
     /**
      * Returns true if the current plug is switchable
      */
-    readonly isSwitchable: boolean;
+    get isSwitchable(): boolean;
     clone(): this;
     /**
      * Creates a proxy which redirects the properties to the correct internal one, does nothing now

--- a/build/lib/utils.d.ts
+++ b/build/lib/utils.d.ts
@@ -1,0 +1,1 @@
+export declare function invertOperation<T extends Record<string, any>>(operation: T): T;

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const objects_1 = require("alcalzone-shared/objects");
+function invertOperation(operation) {
+    return objects_1.composeObject(objects_1.entries(operation).map(([key, value]) => {
+        switch (typeof value) {
+            case "number":
+                return [key, Number.NaN];
+            case "boolean":
+                return [key, !value];
+            default:
+                return [key, null];
+        }
+    }));
+}
+exports.invertOperation = invertOperation;

--- a/build/lib/watcher.d.ts
+++ b/build/lib/watcher.d.ts
@@ -41,7 +41,7 @@ export declare class ConnectionWatcher extends EventEmitter {
     private client;
     constructor(client: TradfriClient, options?: Partial<ConnectionWatcherOptions>);
     private _options;
-    readonly options: ConnectionWatcherOptions;
+    get options(): ConnectionWatcherOptions;
     private pingTimer;
     /** Starts watching the connection */
     start(): void;

--- a/build/tradfri-client.d.ts
+++ b/build/tradfri-client.d.ts
@@ -175,7 +175,7 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
      * Sets some properties on a group
      * @param group The group to be updated
      * @param operation The properties to be set
-     * @param force If the provided properties must be sent in any case
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
     operateGroup(group: Group, operation: GroupOperation, force?: boolean): Promise<boolean>;
@@ -183,23 +183,26 @@ export declare class TradfriClient extends EventEmitter implements OperationProv
      * Sets some properties on a lightbulb
      * @param accessory The parent accessory of the lightbulb
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operateLight(accessory: Accessory, operation: LightOperation): Promise<boolean>;
+    operateLight(accessory: Accessory, operation: LightOperation, force?: boolean): Promise<boolean>;
     /**
      * Sets some properties on a plug
      * @param accessory The parent accessory of the plug
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operatePlug(accessory: Accessory, operation: PlugOperation): Promise<boolean>;
+    operatePlug(accessory: Accessory, operation: PlugOperation, force?: boolean): Promise<boolean>;
     /**
      * Sets some properties on a blind
      * @param accessory The parent accessory of the blind
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operateBlind(accessory: Accessory, operation: BlindOperation): Promise<boolean>;
+    operateBlind(accessory: Accessory, operation: BlindOperation, force?: boolean): Promise<boolean>;
     /**
      * Sends a custom request to a resource
      * @param path The path of the resource

--- a/build/tradfri-client.js
+++ b/build/tradfri-client.js
@@ -15,7 +15,6 @@ const node_coap_client_1 = require("node-coap-client");
 // load internal modules
 const async_1 = require("alcalzone-shared/async");
 const deferred_promise_1 = require("alcalzone-shared/deferred-promise");
-const objects_1 = require("alcalzone-shared/objects");
 const accessory_1 = require("./lib/accessory");
 const array_extensions_1 = require("./lib/array-extensions");
 const endpoints_1 = require("./lib/endpoints");
@@ -26,6 +25,7 @@ const notification_1 = require("./lib/notification");
 const scene_1 = require("./lib/scene");
 const tradfri_error_1 = require("./lib/tradfri-error");
 const watcher_1 = require("./lib/watcher");
+const utils_1 = require("./lib/utils");
 class TradfriClient extends events_1.EventEmitter {
     // tslint:enable:unified-signatures
     constructor(hostname, optionsOrLogger) {
@@ -815,7 +815,7 @@ class TradfriClient extends events_1.EventEmitter {
      * Sets some properties on a group
      * @param group The group to be updated
      * @param operation The properties to be set
-     * @param force If the provided properties must be sent in any case
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
     operateGroup(group, operation, force = false) {
@@ -823,15 +823,7 @@ class TradfriClient extends events_1.EventEmitter {
         const reference = group.clone();
         if (force) {
             // to force the properties being sent, we need to reset them on the reference
-            const inverseOperation = objects_1.composeObject(objects_1.entries(operation)
-                .map(([key, value]) => {
-                switch (typeof value) {
-                    case "number": return [key, Number.NaN];
-                    case "boolean": return [key, !value];
-                    default: return [key, null];
-                }
-            }));
-            reference.merge(inverseOperation, true);
+            reference.merge(utils_1.invertOperation(operation), true);
         }
         return this.updateResource(`${endpoints_1.endpoints.groups}/${group.instanceId}`, newGroup, reference);
     }
@@ -839,45 +831,60 @@ class TradfriClient extends events_1.EventEmitter {
      * Sets some properties on a lightbulb
      * @param accessory The parent accessory of the lightbulb
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operateLight(accessory, operation) {
+    operateLight(accessory, operation, force = false) {
         if (accessory.type !== accessory_1.AccessoryTypes.lightbulb) {
             throw new Error("The parameter accessory must be a lightbulb!");
         }
-        const reference = accessory.clone();
-        const newAccessory = reference.clone();
+        const newAccessory = accessory.clone();
         newAccessory.lightList[0].merge(operation);
+        const reference = accessory.clone();
+        if (force) {
+            // to force the properties being sent, we need to reset them on the reference
+            reference.lightList[0].merge(utils_1.invertOperation(operation), true);
+        }
         return this.updateResource(`${endpoints_1.endpoints.devices}/${accessory.instanceId}`, newAccessory, reference);
     }
     /**
      * Sets some properties on a plug
      * @param accessory The parent accessory of the plug
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operatePlug(accessory, operation) {
+    operatePlug(accessory, operation, force = false) {
         if (accessory.type !== accessory_1.AccessoryTypes.plug) {
             throw new Error("The parameter accessory must be a plug!");
         }
-        const reference = accessory.clone();
-        const newAccessory = reference.clone();
+        const newAccessory = accessory.clone();
         newAccessory.plugList[0].merge(operation);
+        const reference = accessory.clone();
+        if (force) {
+            // to force the properties being sent, we need to reset them on the reference
+            reference.plugList[0].merge(utils_1.invertOperation(operation), true);
+        }
         return this.updateResource(`${endpoints_1.endpoints.devices}/${accessory.instanceId}`, newAccessory, reference);
     }
     /**
      * Sets some properties on a blind
      * @param accessory The parent accessory of the blind
      * @param operation The properties to be set
+     * @param force Include all properties of operation in the payload, even if the values are unchanged
      * @returns true if a request was sent, false otherwise
      */
-    operateBlind(accessory, operation) {
+    operateBlind(accessory, operation, force = false) {
         if (accessory.type !== accessory_1.AccessoryTypes.blind) {
             throw new Error("The parameter accessory must be a blind!");
         }
-        const reference = accessory.clone();
-        const newAccessory = reference.clone();
+        const newAccessory = accessory.clone();
         newAccessory.blindList[0].merge(operation);
+        const reference = accessory.clone();
+        if (force) {
+            // to force the properties being sent, we need to reset them on the reference
+            reference.blindList[0].merge(utils_1.invertOperation(operation), true);
+        }
         return this.updateResource(`${endpoints_1.endpoints.devices}/${accessory.instanceId}`, newAccessory, reference);
     }
     /**

--- a/src/lib/operation-provider.ts
+++ b/src/lib/operation-provider.ts
@@ -6,7 +6,7 @@ import { PlugOperation } from "./plug";
 
 export interface OperationProvider {
 	operateGroup(group: Group, operation: GroupOperation, force?: boolean): Promise<boolean>;
-	operateLight(accessory: Accessory, operation: LightOperation): Promise<boolean>;
-	operatePlug(accessory: Accessory, operation: PlugOperation): Promise<boolean>;
-	operateBlind(accessory: Accessory, operation: BlindOperation): Promise<boolean>;
+	operateLight(accessory: Accessory, operation: LightOperation, force?: boolean): Promise<boolean>;
+	operatePlug(accessory: Accessory, operation: PlugOperation, force?: boolean): Promise<boolean>;
+	operateBlind(accessory: Accessory, operation: BlindOperation, force?: boolean): Promise<boolean>;
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,74 @@
+// tslint:disable:no-unused-expression
+import { invertOperation } from "./utils";
+import { assert, expect } from "chai";
+
+describe("lib/utils => invertOperation() =>", () => {
+	it("leaves empty operations untouched", () => {
+		expect(invertOperation({})).to.deep.equal({});
+	});
+
+	it("sets numeric properties to NaN", () => {
+		expect(
+			invertOperation({
+				foo: 5
+			})
+		).to.deep.equal({
+			foo: NaN
+		});
+	});
+
+	it("sets boolean properties to the opposite value", () => {
+		expect(
+			invertOperation({
+				bar: true
+			})
+		).to.deep.equal({
+			bar: false
+		});
+		expect(
+			invertOperation({
+				baz: false
+			})
+		).to.deep.equal({
+			baz: true
+		});
+	});
+
+	it("sets all other properties to null", () => {
+		expect(
+			invertOperation({
+				foo: "string"
+			})
+		).to.deep.equal({
+			foo: null
+		});
+		expect(
+			invertOperation({
+				foo: {}
+			})
+		).to.deep.equal({
+			foo: null
+		});
+		expect(
+			invertOperation({
+				foo: () => {}
+			})
+		).to.deep.equal({
+			foo: null
+		});
+	});
+
+	it("works for multiple properties", () => {
+		expect(
+			invertOperation({
+				foo: "string",
+				bar: true,
+				baz: 8
+			})
+		).to.deep.equal({
+			foo: null,
+			bar: false,
+			baz: NaN
+		});
+	});
+});

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-unused-expression
-import { invertOperation } from "./utils";
 import { assert, expect } from "chai";
+import { invertOperation } from "./utils";
 
 describe("lib/utils => invertOperation() =>", () => {
 	it("leaves empty operations untouched", () => {
@@ -10,51 +10,51 @@ describe("lib/utils => invertOperation() =>", () => {
 	it("sets numeric properties to NaN", () => {
 		expect(
 			invertOperation({
-				foo: 5
-			})
+				foo: 5,
+			}),
 		).to.deep.equal({
-			foo: NaN
+			foo: NaN,
 		});
 	});
 
 	it("sets boolean properties to the opposite value", () => {
 		expect(
 			invertOperation({
-				bar: true
-			})
+				bar: true,
+			}),
 		).to.deep.equal({
-			bar: false
+			bar: false,
 		});
 		expect(
 			invertOperation({
-				baz: false
-			})
+				baz: false,
+			}),
 		).to.deep.equal({
-			baz: true
+			baz: true,
 		});
 	});
 
 	it("sets all other properties to null", () => {
 		expect(
 			invertOperation({
-				foo: "string"
-			})
+				foo: "string",
+			}),
 		).to.deep.equal({
-			foo: null
+			foo: null,
 		});
 		expect(
 			invertOperation({
-				foo: {}
-			})
+				foo: {},
+			}),
 		).to.deep.equal({
-			foo: null
+			foo: null,
 		});
 		expect(
 			invertOperation({
-				foo: () => {}
-			})
+				foo: () => { /* this is not empty, TSLint! */ },
+			}),
 		).to.deep.equal({
-			foo: null
+			foo: null,
 		});
 	});
 
@@ -63,12 +63,12 @@ describe("lib/utils => invertOperation() =>", () => {
 			invertOperation({
 				foo: "string",
 				bar: true,
-				baz: 8
-			})
+				baz: 8,
+			}),
 		).to.deep.equal({
 			foo: null,
 			bar: false,
-			baz: NaN
+			baz: NaN,
 		});
 	});
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,18 @@
+import { composeObject, entries } from "alcalzone-shared/objects";
+
+export function invertOperation<T extends Record<string, any>>(
+	operation: T
+): T {
+	return composeObject<number | boolean>(
+		entries(operation).map(([key, value]) => {
+			switch (typeof value) {
+				case "number":
+					return [key, Number.NaN] as [string, number];
+				case "boolean":
+					return [key, !value] as [string, boolean];
+				default:
+					return [key, null] as [string, any];
+			}
+		})
+	) as T;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { composeObject, entries } from "alcalzone-shared/objects";
 
 export function invertOperation<T extends Record<string, any>>(
-	operation: T
+	operation: T,
 ): T {
 	return composeObject<number | boolean>(
 		entries(operation).map(([key, value]) => {
@@ -13,6 +13,6 @@ export function invertOperation<T extends Record<string, any>>(
 				default:
 					return [key, null] as [string, any];
 			}
-		})
+		}),
 	) as T;
 }

--- a/src/tradfri-client.ts
+++ b/src/tradfri-client.ts
@@ -20,8 +20,8 @@ import { OperationProvider } from "./lib/operation-provider";
 import { PlugOperation } from "./lib/plug";
 import { Scene } from "./lib/scene";
 import { TradfriError, TradfriErrorCodes } from "./lib/tradfri-error";
-import { ConnectionWatcher, ConnectionWatcherOptions } from "./lib/watcher";
 import { invertOperation } from "./lib/utils";
+import { ConnectionWatcher, ConnectionWatcherOptions } from "./lib/watcher";
 
 export type ObserveResourceCallback = (resp: CoapResponse) => void;
 export type ObserveDevicesCallback = (addedDevices: Accessory[], removedDevices: Accessory[]) => void;
@@ -1001,7 +1001,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 		const reference = group.clone();
 		if (force) {
 			// to force the properties being sent, we need to reset them on the reference
-			reference.merge(invertOperation(operation), true)
+			reference.merge(invertOperation(operation), true);
 		}
 
 		return this.updateResource(
@@ -1027,7 +1027,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 		const reference = accessory.clone();
 		if (force) {
 			// to force the properties being sent, we need to reset them on the reference
-			reference.lightList[0].merge(invertOperation(operation), true)
+			reference.lightList[0].merge(invertOperation(operation), true);
 		}
 
 		return this.updateResource(
@@ -1053,7 +1053,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 		const reference = accessory.clone();
 		if (force) {
 			// to force the properties being sent, we need to reset them on the reference
-			reference.plugList[0].merge(invertOperation(operation), true)
+			reference.plugList[0].merge(invertOperation(operation), true);
 		}
 
 		return this.updateResource(
@@ -1079,7 +1079,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 		const reference = accessory.clone();
 		if (force) {
 			// to force the properties being sent, we need to reset them on the reference
-			reference.blindList[0].merge(invertOperation(operation), true)
+			reference.blindList[0].merge(invertOperation(operation), true);
 		}
 
 		return this.updateResource(

--- a/src/tradfri-client.ts
+++ b/src/tradfri-client.ts
@@ -5,7 +5,6 @@ import { CoapClient as coap, CoapResponse, ConnectionResult, RequestMethod } fro
 // load internal modules
 import { wait } from "alcalzone-shared/async";
 import { createDeferredPromise, DeferredPromise } from "alcalzone-shared/deferred-promise";
-import { composeObject, entries } from "alcalzone-shared/objects";
 import { Accessory, AccessoryTypes } from "./lib/accessory";
 import { except } from "./lib/array-extensions";
 import { BlindOperation } from "./lib/blind";
@@ -22,6 +21,7 @@ import { PlugOperation } from "./lib/plug";
 import { Scene } from "./lib/scene";
 import { TradfriError, TradfriErrorCodes } from "./lib/tradfri-error";
 import { ConnectionWatcher, ConnectionWatcherOptions } from "./lib/watcher";
+import { invertOperation } from "./lib/utils";
 
 export type ObserveResourceCallback = (resp: CoapResponse) => void;
 export type ObserveDevicesCallback = (addedDevices: Accessory[], removedDevices: Accessory[]) => void;
@@ -992,7 +992,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	 * Sets some properties on a group
 	 * @param group The group to be updated
 	 * @param operation The properties to be set
-	 * @param force If the provided properties must be sent in any case
+	 * @param force Include all properties of operation in the payload, even if the values are unchanged
 	 * @returns true if a request was sent, false otherwise
 	 */
 	public operateGroup(group: Group, operation: GroupOperation, force: boolean = false): Promise<boolean> {
@@ -1001,17 +1001,7 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 		const reference = group.clone();
 		if (force) {
 			// to force the properties being sent, we need to reset them on the reference
-			const inverseOperation = composeObject<number | boolean>(
-				entries(operation)
-					.map(([key, value]) => {
-						switch (typeof value) {
-							case "number": return [key, Number.NaN] as [string, number];
-							case "boolean": return [key, !value] as [string, boolean];
-							default: return [key, null] as [string, any];
-						}
-					}),
-			);
-			reference.merge(inverseOperation, true);
+			reference.merge(invertOperation(operation), true)
 		}
 
 		return this.updateResource(
@@ -1024,16 +1014,21 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	 * Sets some properties on a lightbulb
 	 * @param accessory The parent accessory of the lightbulb
 	 * @param operation The properties to be set
+	 * @param force Include all properties of operation in the payload, even if the values are unchanged
 	 * @returns true if a request was sent, false otherwise
 	 */
-	public operateLight(accessory: Accessory, operation: LightOperation): Promise<boolean> {
+	public operateLight(accessory: Accessory, operation: LightOperation, force: boolean = false): Promise<boolean> {
 		if (accessory.type !== AccessoryTypes.lightbulb) {
 			throw new Error("The parameter accessory must be a lightbulb!");
 		}
 
-		const reference = accessory.clone();
-		const newAccessory = reference.clone();
+		const newAccessory = accessory.clone();
 		newAccessory.lightList[0].merge(operation);
+		const reference = accessory.clone();
+		if (force) {
+			// to force the properties being sent, we need to reset them on the reference
+			reference.lightList[0].merge(invertOperation(operation), true)
+		}
 
 		return this.updateResource(
 			`${coapEndpoints.devices}/${accessory.instanceId}`,
@@ -1045,16 +1040,21 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	 * Sets some properties on a plug
 	 * @param accessory The parent accessory of the plug
 	 * @param operation The properties to be set
+	 * @param force Include all properties of operation in the payload, even if the values are unchanged
 	 * @returns true if a request was sent, false otherwise
 	 */
-	public operatePlug(accessory: Accessory, operation: PlugOperation): Promise<boolean> {
+	public operatePlug(accessory: Accessory, operation: PlugOperation, force: boolean = false): Promise<boolean> {
 		if (accessory.type !== AccessoryTypes.plug) {
 			throw new Error("The parameter accessory must be a plug!");
 		}
 
-		const reference = accessory.clone();
-		const newAccessory = reference.clone();
+		const newAccessory = accessory.clone();
 		newAccessory.plugList[0].merge(operation);
+		const reference = accessory.clone();
+		if (force) {
+			// to force the properties being sent, we need to reset them on the reference
+			reference.plugList[0].merge(invertOperation(operation), true)
+		}
 
 		return this.updateResource(
 			`${coapEndpoints.devices}/${accessory.instanceId}`,
@@ -1066,16 +1066,21 @@ export class TradfriClient extends EventEmitter implements OperationProvider {
 	 * Sets some properties on a blind
 	 * @param accessory The parent accessory of the blind
 	 * @param operation The properties to be set
+	 * @param force Include all properties of operation in the payload, even if the values are unchanged
 	 * @returns true if a request was sent, false otherwise
 	 */
-	public operateBlind(accessory: Accessory, operation: BlindOperation): Promise<boolean> {
+	public operateBlind(accessory: Accessory, operation: BlindOperation, force: boolean = false): Promise<boolean> {
 		if (accessory.type !== AccessoryTypes.blind) {
 			throw new Error("The parameter accessory must be a blind!");
 		}
 
-		const reference = accessory.clone();
-		const newAccessory = reference.clone();
+		const newAccessory = accessory.clone();
 		newAccessory.blindList[0].merge(operation);
+		const reference = accessory.clone();
+		if (force) {
+			// to force the properties being sent, we need to reset them on the reference
+			reference.blindList[0].merge(invertOperation(operation), true)
+		}
 
 		return this.updateResource(
 			`${coapEndpoints.devices}/${accessory.instanceId}`,


### PR DESCRIPTION
When this parameter is true, the entire `operation` object will be sent in the payload, not just the changed values.